### PR TITLE
Allow music to loop forever

### DIFF
--- a/include/ge211_audio.hxx
+++ b/include/ge211_audio.hxx
@@ -79,7 +79,7 @@ private:
 /// Note that Music_track has few public member functions. However, a
 /// music track can be passed to these Mixer member functions to play it:
 ///
-///  - @ref Mixer::play_music(Music_track)
+///  - @ref Mixer::play_music(Music_track, bool)
 ///  - @ref Mixer::attach_music(Music_track)
 ///
 /// Note also that the mixer can only play one music track at a time.
@@ -219,13 +219,14 @@ public:
     ///@{
 
     /// Attaches the given music track to this mixer and starts it playing.
+    /// Loops music forever if requested.
     /// Equivalent to @ref Mixer::attach_music followed by
     /// @ref Mixer::resume_music.
     ///
     /// \preconditions
     ///  - `get_music_state()` is `paused` or `detached`; throws
     ///    exceptions::Client_logic_error if violated.
-    void play_music(Music_track);
+    void play_music(Music_track, bool forever = true);
 
     /// Attaches the given music track to this mixer. Give the empty
     /// Music_track to detach the current track, if any, without attaching a
@@ -237,12 +238,12 @@ public:
     void attach_music(Music_track);
 
     /// Plays the currently attached music from the current saved position,
-    /// fading in if requested.
+    /// fading in if requested and looping forever unless requested.
     ///
     /// \preconditions
     ///  - `get_music_state()` is `paused` or `playing`; throws
     ///    exceptions::Client_logic_error if violated.
-    void resume_music(Duration fade_in = Duration(0));
+    void resume_music(Duration fade_in = Duration(0), bool forever = true);
 
     /// Pauses the currently attached music, fading out if requested.
     ///

--- a/include/ge211_audio.hxx
+++ b/include/ge211_audio.hxx
@@ -219,14 +219,16 @@ public:
     ///@{
 
     /// Attaches the given music track to this mixer and starts it playing.
-    /// Loops music forever if requested.
+    /// Loops forever if given `true` for `forever`; otherwise when the
+    /// music track finishes, the mixer rewinds and pauses it.
+    ///
     /// Equivalent to @ref Mixer::attach_music followed by
     /// @ref Mixer::resume_music.
     ///
     /// \preconditions
     ///  - `get_music_state()` is `paused` or `detached`; throws
     ///    exceptions::Client_logic_error if violated.
-    void play_music(Music_track, bool forever = true);
+    void play_music(Music_track, bool forever = false);
 
     /// Attaches the given music track to this mixer. Give the empty
     /// Music_track to detach the current track, if any, without attaching a
@@ -237,13 +239,15 @@ public:
     ///    exceptions::Client_logic_error if violated.
     void attach_music(Music_track);
 
-    /// Plays the currently attached music from the current saved position,
-    /// fading in if requested and looping forever unless requested.
+    /// Plays the currently attached music from the current saved position.
+    /// Fades in if given a non-zero @ref Duration for `fade_in`.
+    /// Loops forever if given `true` for `forever`; otherwise when the
+    /// music track finishes, the mixer rewinds and pauses it.
     ///
     /// \preconditions
     ///  - `get_music_state()` is `paused` or `playing`; throws
     ///    exceptions::Client_logic_error if violated.
-    void resume_music(Duration fade_in = Duration(0), bool forever = true);
+    void resume_music(Duration fade_in = Duration(0), bool forever = false);
 
     /// Pauses the currently attached music, fading out if requested.
     ///

--- a/src/ge211_audio.cxx
+++ b/src/ge211_audio.cxx
@@ -141,10 +141,10 @@ Mixer::~Mixer()
 }
 
 
-void Mixer::play_music(Music_track music)
+void Mixer::play_music(Music_track music, bool forever)
 {
     attach_music(std::move(music));
-    resume_music();
+    resume_music(forever);
 }
 
 void Mixer::attach_music(Music_track music)
@@ -170,8 +170,15 @@ void Mixer::attach_music(Music_track music)
     }
 }
 
-void Mixer::resume_music(Duration fade_in)
+void Mixer::resume_music(Duration fade_in, bool forever)
 {
+    // 0 plays the music once
+    int loops = 0;
+    if (forever) {
+        // -1 plays the music forever, looping it
+        loops = -1;
+    }
+
     switch (music_state_) {
         case State::detached:
             throw Client_logic_error("Mixer::resume_music: no music attached");
@@ -179,7 +186,7 @@ void Mixer::resume_music(Duration fade_in)
         case State::paused:
             Mix_RewindMusic();
             Mix_FadeInMusicPos(current_music_.ptr_.get(),
-                               0,
+                               loops,
                                int(fade_in.milliseconds()),
                                music_position_.elapsed_time().seconds());
             music_position_.resume();

--- a/src/ge211_audio.cxx
+++ b/src/ge211_audio.cxx
@@ -144,7 +144,7 @@ Mixer::~Mixer()
 void Mixer::play_music(Music_track music, bool forever)
 {
     attach_music(std::move(music));
-    resume_music(forever);
+    resume_music(Duration(0), forever);
 }
 
 void Mixer::attach_music(Music_track music)
@@ -172,13 +172,6 @@ void Mixer::attach_music(Music_track music)
 
 void Mixer::resume_music(Duration fade_in, bool forever)
 {
-    // 0 plays the music once
-    int loops = 0;
-    if (forever) {
-        // -1 plays the music forever, looping it
-        loops = -1;
-    }
-
     switch (music_state_) {
         case State::detached:
             throw Client_logic_error("Mixer::resume_music: no music attached");
@@ -186,7 +179,7 @@ void Mixer::resume_music(Duration fade_in, bool forever)
         case State::paused:
             Mix_RewindMusic();
             Mix_FadeInMusicPos(current_music_.ptr_.get(),
-                               loops,
+                               forever? -1 : 0,
                                int(fade_in.milliseconds()),
                                music_position_.elapsed_time().seconds());
             music_position_.resume();


### PR DESCRIPTION
This PR adds an option for music played by the mixer to loop indefinitely. ([SDL docs](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_59.html))

It also enables that option by default, because I think it is the default people usually want, but I don't feel too strongly about that.

I think I got all the documentation in the right places and think this will work, but haven't tested or even compiled it.