### PR TITLE
Bugfix: adding messages to a builder

### DIFF
--- a/src/sprites.cxx
+++ b/src/sprites.cxx
@@ -258,8 +258,8 @@ void Text_sprite::assert_initialized_() const
 }
 
 Text_sprite::Builder::Builder(const Font& font)
-        : message_{}, font_{&font}, color_{Color::white()}, antialias_{true},
-          word_wrap_{0} {}
+        : message_{"", std::ios_base::app}, font_{&font},
+          color_{Color::white()}, antialias_{true}, word_wrap_{0} {}
 
 Text_sprite::Builder& Text_sprite::Builder::message(const std::string& message)
 {


### PR DESCRIPTION
Builders use a `std::ostreamstring` internally to store the message. `Builder::message()` overwrites this, but surprisingly doesn't update the position to the end of the stream by default, so future `Builder::add_message()` calls overwrite the base message.

This is "the design" of `std::ostreamstring` and can be fixed with a constructor argument: https://stackoverflow.com/questions/62238203/stdostringstream-overwriting-initializing-string